### PR TITLE
Remove href formatting

### DIFF
--- a/search_amazon.rb
+++ b/search_amazon.rb
@@ -40,9 +40,6 @@ class Mechanize
                                     .first
                                     .attributes['href']
                                     .value
-                                    .match(%r{/dp/\d+})
-                                    .to_s
-        "#{AMAZON_JP_URL}#{product_code}"
       end
 
       def price(search_result)


### PR DESCRIPTION
Product id is not only include that %r{/dp/(\d+)} regular expression
There is another patterns.
